### PR TITLE
update the end of the routine  _CheckInRAM_ASM

### DIFF
--- a/fileio/fileio_src/v2/fileio_lib.asm
+++ b/fileio/fileio_src/v2/fileio_lib.asm
@@ -161,8 +161,8 @@ _CheckInRAM_ASM:
 	dec hl
 	ld 	a,$cf
 	cp	(hl)
-	sbc	a,a
-	inc	a
+	sbc	hl,hl
+	inc	hl
 	ret
  
 ;-------------------------------------------------------------------------------


### PR DESCRIPTION
put the useful register HL back : 
replace register A , &  the value of HL will be either 0 or 1 as seen before.